### PR TITLE
エコーサーバー・クライアントの実装（最小限）

### DIFF
--- a/client.c
+++ b/client.c
@@ -1,24 +1,45 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
 int main(int argc, char **argv)
 {
+    // TODO: Refactor redundant error handling
+    int result = 0;
+
     int sock = socket(PF_INET, SOCK_STREAM, 0);
+    if (sock == -1)
+    {
+        perror("client: socket()");
+        exit(1);
+    }
 
     struct sockaddr_in client_addr;
     client_addr.sin_family = PF_INET;
     client_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
     client_addr.sin_port = htons(8080);
-    connect(sock, (struct sockaddr *)&client_addr, sizeof(client_addr));
+    result = connect(sock, (struct sockaddr *)&client_addr, sizeof(client_addr));
+    if (result == -1)
+    {
+        perror("client: connect()");
+        close(sock);
+        exit(1);
+    }
 
     char buf[256];
     fgets(buf, sizeof(buf) - 1, stdin);
 
-    send(sock, buf, sizeof(buf), 0);
+    result = send(sock, buf, sizeof(buf), 0);
+    if (result == -1)
+    {
+        perror("client: connect()");
+        close(sock);
+        exit(1);
+    }
 
     close(sock);
 

--- a/client.c
+++ b/client.c
@@ -8,11 +8,8 @@
 
 int main(int argc, char **argv)
 {
-    // TODO: Refactor redundant error handling
-    int result = 0;
-
-    int sock = socket(PF_INET, SOCK_STREAM, 0);
-    if (sock == -1)
+    int sock;
+    if ((sock = socket(PF_INET, SOCK_STREAM, 0)) == -1)
     {
         perror("client: socket()");
         exit(1);
@@ -22,8 +19,7 @@ int main(int argc, char **argv)
     server_addr.sin_family = PF_INET;
     server_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
     server_addr.sin_port = htons(8080);
-    result = connect(sock, (struct sockaddr *)&server_addr, sizeof(server_addr));
-    if (result == -1)
+    if (connect(sock, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
     {
         perror("client: connect()");
         close(sock);
@@ -33,16 +29,14 @@ int main(int argc, char **argv)
     char buf[256] = {0};
     fgets(buf, sizeof(buf) - 1, stdin);
 
-    result = send(sock, buf, sizeof(buf), 0);
-    if (result == -1)
+    if (send(sock, buf, sizeof(buf), 0) == -1)
     {
         perror("client: send()");
         close(sock);
         exit(1);
     }
 
-    result = recv(sock, buf, sizeof(buf) - 1, 0);
-    if (result == -1)
+    if (recv(sock, buf, sizeof(buf) - 1, 0) == -1)
     {
         perror("client: recv()");
         close(sock);

--- a/client.c
+++ b/client.c
@@ -18,11 +18,11 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    struct sockaddr_in client_addr;
-    client_addr.sin_family = PF_INET;
-    client_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
-    client_addr.sin_port = htons(8080);
-    result = connect(sock, (struct sockaddr *)&client_addr, sizeof(client_addr));
+    struct sockaddr_in server_addr;
+    server_addr.sin_family = PF_INET;
+    server_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+    server_addr.sin_port = htons(8080);
+    result = connect(sock, (struct sockaddr *)&server_addr, sizeof(server_addr));
     if (result == -1)
     {
         perror("client: connect()");

--- a/client.c
+++ b/client.c
@@ -1,0 +1,26 @@
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+int main(int argc, char **argv)
+{
+    struct sockaddr_in client_addr;
+
+    int sock = socket(PF_INET, SOCK_STREAM, 0);
+
+    client_addr.sin_family = PF_INET;
+    client_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+    client_addr.sin_port = htons(8080);
+    connect(sock, (struct sockaddr *)&client_addr, sizeof(client_addr));
+
+    char buf[256];
+    strcpy(buf, "hello");
+
+    send(sock, buf, sizeof(buf), 0);
+
+    close(sock);
+
+    return 0;
+}

--- a/client.c
+++ b/client.c
@@ -1,5 +1,6 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <stdio.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -15,7 +16,7 @@ int main(int argc, char **argv)
     connect(sock, (struct sockaddr *)&client_addr, sizeof(client_addr));
 
     char buf[256];
-    strcpy(buf, "hello");
+    fgets(buf, sizeof(buf) - 1, stdin);
 
     send(sock, buf, sizeof(buf), 0);
 

--- a/client.c
+++ b/client.c
@@ -26,10 +26,11 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    char buf[256] = {0};
-    fgets(buf, sizeof(buf) - 1, stdin);
+    char buf[256];
+    fgets(buf, sizeof(buf), stdin); // Null-terminate the string
 
-    if (send(sock, buf, sizeof(buf), 0) == -1)
+    size_t len = strlen(buf);
+    if (send(sock, buf, len, 0) == -1)
     {
         perror("client: send()");
         close(sock);

--- a/client.c
+++ b/client.c
@@ -6,10 +6,9 @@
 
 int main(int argc, char **argv)
 {
-    struct sockaddr_in client_addr;
-
     int sock = socket(PF_INET, SOCK_STREAM, 0);
 
+    struct sockaddr_in client_addr;
     client_addr.sin_family = PF_INET;
     client_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
     client_addr.sin_port = htons(8080);

--- a/client.c
+++ b/client.c
@@ -30,16 +30,26 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    char buf[256];
+    char buf[256] = {0};
     fgets(buf, sizeof(buf) - 1, stdin);
 
     result = send(sock, buf, sizeof(buf), 0);
     if (result == -1)
     {
-        perror("client: connect()");
+        perror("client: send()");
         close(sock);
         exit(1);
     }
+
+    result = recv(sock, buf, sizeof(buf) - 1, 0);
+    if (result == -1)
+    {
+        perror("client: recv()");
+        close(sock);
+        exit(1);
+    }
+
+    printf("%s", buf);
 
     close(sock);
 

--- a/server.c
+++ b/server.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    for (;;)
+    while (1)
     {
         unsigned int client_len;
         struct sockaddr_in client_addr;
@@ -48,7 +48,7 @@ int main(int argc, char **argv)
             exit(1);
         }
 
-        char buf[256];
+        char buf[256] = {0};
         result = recv(conn_sock, buf, sizeof(buf) - 1, 0);
         if (result == -1)
         {
@@ -58,7 +58,14 @@ int main(int argc, char **argv)
             exit(1);
         }
 
-        printf("%s", buf);
+        result = send(conn_sock, buf, sizeof(buf), 0);
+        if (result == -1)
+        {
+            perror("server: send()");
+            close(conn_sock);
+            close(listen_sock);
+            exit(1);
+        }
 
         close(conn_sock);
     }

--- a/server.c
+++ b/server.c
@@ -16,11 +16,11 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    struct sockaddr_in receiver_addr;
-    receiver_addr.sin_family = PF_INET;
-    receiver_addr.sin_addr.s_addr = INADDR_ANY;
-    receiver_addr.sin_port = htons(8080); // host to network short
-    result = bind(listen_sock, (struct sockaddr *)&receiver_addr, sizeof(receiver_addr));
+    struct sockaddr_in server_addr;
+    server_addr.sin_family = PF_INET;
+    server_addr.sin_addr.s_addr = INADDR_ANY;
+    server_addr.sin_port = htons(8080);
+    result = bind(listen_sock, (struct sockaddr *)&server_addr, sizeof(server_addr));
     if (result == -1)
     {
         perror("server: bind()");
@@ -38,9 +38,9 @@ int main(int argc, char **argv)
 
     for (;;)
     {
-        int sender_len;
-        struct sockaddr_in sender_addr;
-        int conn_sock = accept(listen_sock, (struct sockaddr *)&sender_addr, &sender_len);
+        int client_len;
+        struct sockaddr_in client_addr;
+        int conn_sock = accept(listen_sock, (struct sockaddr *)&client_addr, &client_len);
         if (conn_sock == -1)
         {
             perror("server: accept()");
@@ -58,7 +58,7 @@ int main(int argc, char **argv)
             exit(1);
         }
 
-        printf("%s\n", buf);
+        printf("%s", buf);
 
         close(conn_sock);
     }

--- a/server.c
+++ b/server.c
@@ -5,26 +5,26 @@
 
 int main(int argc, char **argv)
 {
-    int sender_len;
-    struct sockaddr_in receiver_addr, sender_addr;
+    int listen_sock = socket(PF_INET, SOCK_STREAM, 0);
 
-    int sock = socket(PF_INET, SOCK_STREAM, 0);
-
+    struct sockaddr_in receiver_addr;
     receiver_addr.sin_family = PF_INET;
     receiver_addr.sin_addr.s_addr = INADDR_ANY;
-    receiver_addr.sin_port = htons(8080);
-    bind(sock, (struct sockaddr *)&receiver_addr, sizeof(receiver_addr));
+    receiver_addr.sin_port = htons(8080); // host to network short
+    bind(listen_sock, (struct sockaddr *)&receiver_addr, sizeof(receiver_addr));
 
-    listen(sock, 1);
+    listen(listen_sock, 0);
 
-    int sock2 = accept(sock, (struct sockaddr *)&sender_addr, &sender_len);
+    int sender_len;
+    struct sockaddr_in sender_addr;
+    int conn_sock = accept(listen_sock, (struct sockaddr *)&sender_addr, &sender_len);
 
     char buf[256];
-    recv(sock2, buf, sizeof(buf), 0);
+    recv(conn_sock, buf, sizeof(buf) - 1, 0);
     printf("%s\n", buf);
 
-    close(sock);
-    close(sock2);
+    close(listen_sock);
+    close(conn_sock);
 
     return 0;
 }

--- a/server.c
+++ b/server.c
@@ -1,28 +1,63 @@
 #include <netinet/in.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
 int main(int argc, char **argv)
 {
+    // TODO: Refactor redundant error handling
+    int result = 0;
+
     int listen_sock = socket(PF_INET, SOCK_STREAM, 0);
+    if (listen_sock == -1)
+    {
+        perror("server: socket()");
+        exit(1);
+    }
 
     struct sockaddr_in receiver_addr;
     receiver_addr.sin_family = PF_INET;
     receiver_addr.sin_addr.s_addr = INADDR_ANY;
     receiver_addr.sin_port = htons(8080); // host to network short
-    bind(listen_sock, (struct sockaddr *)&receiver_addr, sizeof(receiver_addr));
+    result = bind(listen_sock, (struct sockaddr *)&receiver_addr, sizeof(receiver_addr));
+    if (result == -1)
+    {
+        perror("server: bind()");
+        close(listen_sock);
+        exit(1);
+    }
 
-    listen(listen_sock, 0);
+    result = listen(listen_sock, 0);
+    if (result == -1)
+    {
+        perror("server: listen()");
+        close(listen_sock);
+        exit(1);
+    }
 
     for (;;)
     {
         int sender_len;
         struct sockaddr_in sender_addr;
         int conn_sock = accept(listen_sock, (struct sockaddr *)&sender_addr, &sender_len);
+        if (conn_sock == -1)
+        {
+            perror("server: accept()");
+            close(listen_sock);
+            exit(1);
+        }
 
         char buf[256];
-        recv(conn_sock, buf, sizeof(buf) - 1, 0);
+        result = recv(conn_sock, buf, sizeof(buf) - 1, 0);
+        if (result == -1)
+        {
+            perror("server: recv()");
+            close(conn_sock);
+            close(listen_sock);
+            exit(1);
+        }
+
         printf("%s\n", buf);
 
         close(conn_sock);

--- a/server.c
+++ b/server.c
@@ -6,11 +6,8 @@
 
 int main(int argc, char **argv)
 {
-    // TODO: Refactor redundant error handling
-    int result = 0;
-
-    int listen_sock = socket(PF_INET, SOCK_STREAM, 0);
-    if (listen_sock == -1)
+    int listen_sock;
+    if ((listen_sock = socket(PF_INET, SOCK_STREAM, 0)) == -1)
     {
         perror("server: socket()");
         exit(1);
@@ -20,16 +17,14 @@ int main(int argc, char **argv)
     server_addr.sin_family = PF_INET;
     server_addr.sin_addr.s_addr = INADDR_ANY;
     server_addr.sin_port = htons(8080);
-    result = bind(listen_sock, (struct sockaddr *)&server_addr, sizeof(server_addr));
-    if (result == -1)
+    if (bind(listen_sock, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
     {
         perror("server: bind()");
         close(listen_sock);
         exit(1);
     }
 
-    result = listen(listen_sock, 0);
-    if (result == -1)
+    if (listen(listen_sock, 0) == -1)
     {
         perror("server: listen()");
         close(listen_sock);
@@ -40,8 +35,8 @@ int main(int argc, char **argv)
     {
         unsigned int client_len;
         struct sockaddr_in client_addr;
-        int conn_sock = accept(listen_sock, (struct sockaddr *)&client_addr, &client_len);
-        if (conn_sock == -1)
+        int conn_sock;
+        if ((conn_sock = accept(listen_sock, (struct sockaddr *)&client_addr, &client_len)) == -1)
         {
             perror("server: accept()");
             close(listen_sock);
@@ -49,8 +44,7 @@ int main(int argc, char **argv)
         }
 
         char buf[256] = {0};
-        result = recv(conn_sock, buf, sizeof(buf) - 1, 0);
-        if (result == -1)
+        if (recv(conn_sock, buf, sizeof(buf) - 1, 0) == -1)
         {
             perror("server: recv()");
             close(conn_sock);
@@ -58,8 +52,7 @@ int main(int argc, char **argv)
             exit(1);
         }
 
-        result = send(conn_sock, buf, sizeof(buf), 0);
-        if (result == -1)
+        if (send(conn_sock, buf, sizeof(buf), 0) == -1)
         {
             perror("server: send()");
             close(conn_sock);

--- a/server.c
+++ b/server.c
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
 
     for (;;)
     {
-        int client_len;
+        unsigned int client_len;
         struct sockaddr_in client_addr;
         int conn_sock = accept(listen_sock, (struct sockaddr *)&client_addr, &client_len);
         if (conn_sock == -1)

--- a/server.c
+++ b/server.c
@@ -43,18 +43,23 @@ int main(int argc, char **argv)
             exit(1);
         }
 
-        char buf[256] = {0};
-        if (recv(conn_sock, buf, sizeof(buf) - 1, 0) == -1)
+        char buf[256];
+        ssize_t received_bytes;
+        while ((received_bytes = recv(conn_sock, buf, sizeof(buf) - 1, 0)) > 0)
         {
-            perror("server: recv()");
-            close(conn_sock);
-            close(listen_sock);
-            exit(1);
+            buf[received_bytes] = '\0'; // Null-terminate the string
+            if (send(conn_sock, buf, received_bytes, 0) == -1)
+            {
+                perror("server: send()");
+                close(conn_sock);
+                close(listen_sock);
+                exit(1);
+            }
         }
 
-        if (send(conn_sock, buf, sizeof(buf), 0) == -1)
+        if (received_bytes == -1)
         {
-            perror("server: send()");
+            perror("server: recv()");
             close(conn_sock);
             close(listen_sock);
             exit(1);

--- a/server.c
+++ b/server.c
@@ -1,0 +1,30 @@
+#include <netinet/in.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+int main(int argc, char **argv)
+{
+    int sender_len;
+    struct sockaddr_in receiver_addr, sender_addr;
+
+    int sock = socket(PF_INET, SOCK_STREAM, 0);
+
+    receiver_addr.sin_family = PF_INET;
+    receiver_addr.sin_addr.s_addr = INADDR_ANY;
+    receiver_addr.sin_port = htons(8080);
+    bind(sock, (struct sockaddr *)&receiver_addr, sizeof(receiver_addr));
+
+    listen(sock, 1);
+
+    int sock2 = accept(sock, (struct sockaddr *)&sender_addr, &sender_len);
+
+    char buf[256];
+    recv(sock2, buf, sizeof(buf), 0);
+    printf("%s\n", buf);
+
+    close(sock);
+    close(sock2);
+
+    return 0;
+}

--- a/server.c
+++ b/server.c
@@ -15,16 +15,20 @@ int main(int argc, char **argv)
 
     listen(listen_sock, 0);
 
-    int sender_len;
-    struct sockaddr_in sender_addr;
-    int conn_sock = accept(listen_sock, (struct sockaddr *)&sender_addr, &sender_len);
+    for (;;)
+    {
+        int sender_len;
+        struct sockaddr_in sender_addr;
+        int conn_sock = accept(listen_sock, (struct sockaddr *)&sender_addr, &sender_len);
 
-    char buf[256];
-    recv(conn_sock, buf, sizeof(buf) - 1, 0);
-    printf("%s\n", buf);
+        char buf[256];
+        recv(conn_sock, buf, sizeof(buf) - 1, 0);
+        printf("%s\n", buf);
+
+        close(conn_sock);
+    }
 
     close(listen_sock);
-    close(conn_sock);
 
     return 0;
 }


### PR DESCRIPTION
### Description

クライアント側で標準入力に入力した文字列を送信し、サーバー側で受け取った文字列をそのままクライアント側に送り返し、クライアント側で表示するものを実装
~~クライアント側で標準入力に入力した文字列を送信し、サーバー側でそのまま表示するものを実装~~

- サーバー側は停止するまで無限ループでエコーする
- クライアント側は一度送信すると終了

エラーハンドリングとしては、エラー発生時にすでに作成済みの socket は close してから exit するようにした

- 冗長な感じがあるので別途リファクタリングはしたい（goto 文を使って cleanup 処理を書くとシンプルにできそう、goto 文は一般に非推奨ではあるがこのケースでは可読性が上がる利点が大きそう）

### Usage

以下コマンドでサーバー、クライアントをそれぞれ実行可能

- カレントディレクトリの確認
```bash
$ pwd
/path/to/c-echo
```

- サーバー起動
```bash
$ make run-server
```

- クライアント起動（サーバーとは別ターミナル）
```bash
$ make run-client
```

### Note

ひとまず最小限の実装までなので、大まかな方向性が正しそうであればこの PR をマージして以下の対応に取り組む予定
- 大量のリクエスト処理
- 適切な終了
- IPv6 対応
