### PR TITLE
エコーサーバー・クライアントの実装（いただいたコメントの対応）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ CFLAGS = -Wall -Wextra -Wpedantic -O2
 all: server client
 
 server: server.o utils.o
-	$(CC) $(CFLAGS) -o server server.o utils.o
+	$(CC) $(CFLAGS) -o $@ $^
 
 client: client.o utils.o
-	$(CC) $(CFLAGS) -o client client.o utils.o
+	$(CC) $(CFLAGS) -o $@ $^
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $<

--- a/client.c
+++ b/client.c
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
     int socket_fd;
     if ((socket_fd = create_connected_socket(argv[1], argv[2])) == -1)
     {
-        puts("Failed to create a connected socket\n");
+        fputs("Failed to create a connected socket\n", stderr);
         exit(1);
     }
 
@@ -37,7 +37,7 @@ int main(int argc, char **argv)
             // Check if fgets() reached EOF
             if (feof(stdin))
             {
-                puts("EOF detected\n");
+                puts("EOF detected");
                 break;
             }
             else
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
             }
             else if (received_bytes == 0)
             {
-                puts("Connection closed by server\n");
+                puts("Connection closed by server");
                 close_with_retry(socket_fd);
                 exit(1);
             }
@@ -187,7 +187,7 @@ int create_connected_socket(const char *ip, const char *port_str)
     }
     else
     {
-        puts("Reached the unreachable");
+        fputs("Reached the unreachable\n", stderr);
         return -1;
     }
 

--- a/client.c
+++ b/client.c
@@ -123,9 +123,9 @@ int create_connected_socket(const char *ip, const char *port_str)
     struct sockaddr_in6 server_addr6;
     memset(&server_addr4, 0, sizeof(server_addr4));
     memset(&server_addr6, 0, sizeof(server_addr6));
-    int is_ipv4 = inet_pton(PF_INET, ip, &server_addr4.sin_addr);
-    int is_ipv6 = inet_pton(PF_INET6, ip, &server_addr6.sin6_addr);
-    if (is_ipv4 <= 0 && is_ipv6 <= 0)
+    int ipv4_result = inet_pton(PF_INET, ip, &server_addr4.sin_addr);
+    int ipv6_result = inet_pton(PF_INET6, ip, &server_addr6.sin6_addr);
+    if (ipv4_result <= 0 && ipv6_result <= 0)
     {
         printf("Invalid IP address: %s\n", ip);
         return -1;
@@ -141,7 +141,7 @@ int create_connected_socket(const char *ip, const char *port_str)
 
     // Create a socket and connect to the server
     int socket_fd;
-    if (is_ipv4 == 1)
+    if (ipv4_result == 1)
     {
         if ((socket_fd = socket(PF_INET, SOCK_STREAM, 0)) == -1)
         {
@@ -163,7 +163,7 @@ int create_connected_socket(const char *ip, const char *port_str)
             return -1;
         }
     }
-    else if (is_ipv6 == 1)
+    else if (ipv6_result == 1)
     {
         if ((socket_fd = socket(PF_INET6, SOCK_STREAM, 0)) == -1)
         {

--- a/server.c
+++ b/server.c
@@ -170,11 +170,7 @@ cleanup:
     close_with_retry(pipe_fds[0]);
     close_with_retry(pipe_fds[1]);
 
-    if (exit_code != 0)
-    {
-        exit(exit_code);
-    }
-    return 0;
+    return exit_code;
 }
 
 /**
@@ -245,7 +241,7 @@ int create_listen_sockets(const char *port_str, SocketManager *listen_socket_man
         {
             perror("server: listen()");
             close_with_retry(listen_socket_fd);
-            return -1;
+            continue;
         }
 
         add_socket(listen_socket_manager, listen_socket_fd);

--- a/server.c
+++ b/server.c
@@ -165,8 +165,8 @@ cleanup:
     {
         close_with_retry(epoll_fd);
     }
-    close_all_sockets(client_socket_manager);
-    close_all_sockets(listen_socket_manager);
+    free_socket_manager(client_socket_manager);
+    free_socket_manager(listen_socket_manager);
     close_with_retry(pipe_fds[0]);
     close_with_retry(pipe_fds[1]);
 

--- a/server.c
+++ b/server.c
@@ -19,7 +19,7 @@
 #define MAX_CLIENTS 30
 #define MAX_EVENTS 10
 
-int pipe_fds[2];
+int pipe_fds[2] = {-1, -1};
 
 int create_listen_sockets(const char *port_str, SocketManager *listen_socket_manager);
 int add_listen_sockets_to_epoll(int epoll_fd, SocketManager *listen_socket_manager);
@@ -161,14 +161,20 @@ int main(int argc, char **argv)
     }
 
 cleanup:
+    if (pipe_fds[0] != -1)
+    {
+        close_with_retry(pipe_fds[0]);
+    }
+    if (pipe_fds[1] != -1)
+    {
+        close_with_retry(pipe_fds[1]);
+    }
     if (epoll_fd != -1)
     {
         close_with_retry(epoll_fd);
     }
     free_socket_manager(client_socket_manager);
     free_socket_manager(listen_socket_manager);
-    close_with_retry(pipe_fds[0]);
-    close_with_retry(pipe_fds[1]);
 
     return exit_code;
 }

--- a/server.c
+++ b/server.c
@@ -438,7 +438,7 @@ int handle_new_connection(int listen_socket_fd, int epoll_fd, SocketManager *cli
     }
 
     // Fulfilled the maximum number of clients
-    if (add_socket(client_socket_manager, conn_socket_fd) == -1)
+    if (add_socket(client_socket_manager, conn_socket_fd) == NULL)
     {
         puts("No more room for clients");
         close_with_retry(conn_socket_fd);

--- a/server.c
+++ b/server.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
     init_socket_manager(&listen_socket_manager, MAX_LISTENS);
     if (create_listen_sockets(argv[1], &listen_socket_manager) == -1)
     {
-        puts("Failed to create listen sockets\n");
+        fputs("Failed to create listen sockets\n", stderr);
         exit_code = 1;
         goto cleanup;
     }
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
     // Add the listen sockets to the epoll instance
     if (add_listen_sockets_to_epoll(epoll_fd, &listen_socket_manager) == -1)
     {
-        puts("Failed to add listen sockets to epoll\n");
+        fputs("Failed to add listen sockets to epoll\n", stderr);
         exit_code = 1;
         goto cleanup;
     }
@@ -90,7 +90,7 @@ int main(int argc, char **argv)
     // Add the pipe to the epoll instance
     if (add_pipe_to_epoll(epoll_fd) == -1)
     {
-        puts("Failed to add pipe to epoll\n");
+        fputs("Failed to add pipe to epoll\n", stderr);
         exit_code = 1;
         goto cleanup;
     }
@@ -255,7 +255,7 @@ int create_listen_sockets(const char *port_str, SocketManager *listen_socket_man
 
     if (listen_socket_manager->top == listen_socket_manager->max_size - 1)
     {
-        puts("server: failed to bind any sockets\n");
+        fputs("server: failed to bind any sockets\n", stderr);
         return -1;
     }
 
@@ -440,7 +440,7 @@ int handle_new_connection(int listen_socket_fd, int epoll_fd, SocketManager *cli
     // Fulfilled the maximum number of clients
     if (add_socket(client_socket_manager, conn_socket_fd) == -1)
     {
-        puts("No more room for clients\n");
+        puts("No more room for clients");
         close_with_retry(conn_socket_fd);
         return 0;
     }
@@ -507,7 +507,7 @@ int handle_client(SocketData *client_socket_data, struct epoll_event event)
         }
         else if (received_bytes == 0)
         {
-            puts("Connection closed\n");
+            puts("Connection closed");
             return 0;
         }
         else

--- a/server.c
+++ b/server.c
@@ -550,7 +550,8 @@ int handle_client(SocketData *client_socket_data, struct epoll_event event)
     if (event.events & EPOLLOUT)
     {
         ssize_t sent_bytes;
-        if ((sent_bytes = send(client_socket_data->socket_fd, client_socket_data->buffer, strlen(client_socket_data->buffer), 0)) >= 0)
+        // Set MSG_NOSIGNAL to prevent the server from crashing when the client disconnects
+        if ((sent_bytes = send(client_socket_data->socket_fd, client_socket_data->buffer, strlen(client_socket_data->buffer), MSG_NOSIGNAL)) >= 0)
         {
             memmove(client_socket_data->buffer, client_socket_data->buffer + sent_bytes, strlen(client_socket_data->buffer) - sent_bytes);
             client_socket_data->buffer[strlen(client_socket_data->buffer) - sent_bytes] = '\0';

--- a/server.c
+++ b/server.c
@@ -249,7 +249,7 @@ int create_listen_sockets(const char *port_str, SocketManager *listen_socket_man
 
     freeaddrinfo(res0);
 
-    if (listen_socket_manager->top == listen_socket_manager->max_size - 1)
+    if (get_socket_count(listen_socket_manager) == 0)
     {
         fputs("server: failed to bind any sockets\n", stderr);
         return -1;

--- a/utils.c
+++ b/utils.c
@@ -41,6 +41,7 @@ SocketManager *new_socket_manager(int max_size)
     return manager;
 }
 
+// NO USE
 SocketData *find_socket(SocketManager *manager, int socket_fd)
 {
     if (manager == NULL)
@@ -58,7 +59,7 @@ SocketData *find_socket(SocketManager *manager, int socket_fd)
     return NULL;
 }
 
-SocketData *add_socket(SocketManager *manager, int socket_fd)
+SocketData *add_socket(SocketManager *manager, SocketType type, int socket_fd)
 {
     if (manager == NULL)
     {
@@ -70,6 +71,7 @@ SocketData *add_socket(SocketManager *manager, int socket_fd)
         return NULL;
     }
     int index = manager->free_indices[manager->top--];
+    manager->sockets[index].type = type;
     manager->sockets[index].socket_fd = socket_fd;
     return &manager->sockets[index];
 }

--- a/utils.c
+++ b/utils.c
@@ -6,8 +6,9 @@
 
 #include "utils.h"
 
-void init_socket_manager(SocketManager *manager, int max_size)
+SocketManager *new_socket_manager(int max_size)
 {
+    SocketManager *manager = (SocketManager *)malloc(sizeof(SocketManager));
     manager->sockets = (SocketData *)malloc(max_size * sizeof(SocketData));
     manager->free_indices = (int *)malloc(max_size * sizeof(int));
     manager->max_size = max_size;
@@ -18,6 +19,7 @@ void init_socket_manager(SocketManager *manager, int max_size)
         manager->sockets[i].socket_fd = -1;
         manager->free_indices[i] = i;
     }
+    return manager;
 }
 
 SocketData *find_socket(SocketManager *manager, int socket_fd)

--- a/utils.c
+++ b/utils.c
@@ -59,7 +59,7 @@ int remove_socket(SocketManager *manager, int socket_fd)
     return -1;
 }
 
-int close_all_sockets(SocketManager *manager)
+void free_socket_manager(SocketManager *manager)
 {
     for (int i = 0; i < manager->max_size; i++)
     {
@@ -70,7 +70,6 @@ int close_all_sockets(SocketManager *manager)
     }
     free(manager->sockets);
     free(manager->free_indices);
-    return 0;
 }
 
 int parse_port(const char *port_str)

--- a/utils.c
+++ b/utils.c
@@ -45,6 +45,11 @@ SocketData *add_socket(SocketManager *manager, int socket_fd)
     return &manager->sockets[index];
 }
 
+int get_socket_count(SocketManager *manager)
+{
+    return (manager->max_size - 1) - manager->top;
+}
+
 int remove_socket(SocketManager *manager, int socket_fd)
 {
     for (int i = 0; i < manager->max_size; i++)

--- a/utils.c
+++ b/utils.c
@@ -73,6 +73,8 @@ SocketData *add_socket(SocketManager *manager, SocketType type, int socket_fd)
     int index = manager->free_indices[manager->top--];
     manager->sockets[index].type = type;
     manager->sockets[index].socket_fd = socket_fd;
+    manager->sockets[index].buffer_start = 0;
+    manager->sockets[index].buffer_end = 0;
     return &manager->sockets[index];
 }
 

--- a/utils.c
+++ b/utils.c
@@ -41,24 +41,6 @@ SocketManager *new_socket_manager(int max_size)
     return manager;
 }
 
-// NO USE
-SocketData *find_socket(SocketManager *manager, int socket_fd)
-{
-    if (manager == NULL)
-    {
-        return NULL;
-    }
-
-    for (int i = 0; i < manager->max_size; i++)
-    {
-        if (manager->sockets[i].socket_fd == socket_fd)
-        {
-            return &manager->sockets[i];
-        }
-    }
-    return NULL;
-}
-
 SocketData *add_socket(SocketManager *manager, SocketType type, int socket_fd)
 {
     if (manager == NULL)

--- a/utils.c
+++ b/utils.c
@@ -34,15 +34,15 @@ SocketData *find_socket(SocketManager *manager, int socket_fd)
     return NULL;
 }
 
-int add_socket(SocketManager *manager, int socket_fd)
+SocketData *add_socket(SocketManager *manager, int socket_fd)
 {
     if (manager->top < 0)
     {
-        return -1;
+        return NULL;
     }
     int index = manager->free_indices[manager->top--];
     manager->sockets[index].socket_fd = socket_fd;
-    return index;
+    return &manager->sockets[index];
 }
 
 int remove_socket(SocketManager *manager, int socket_fd)

--- a/utils.c
+++ b/utils.c
@@ -9,8 +9,27 @@
 SocketManager *new_socket_manager(int max_size)
 {
     SocketManager *manager = (SocketManager *)malloc(sizeof(SocketManager));
+    if (manager == NULL)
+    {
+        perror("malloc(sizeof(SocketManager))");
+        return NULL;
+    }
+
     manager->sockets = (SocketData *)malloc(max_size * sizeof(SocketData));
+    if (manager->sockets == NULL)
+    {
+        perror("malloc(max_size * sizeof(SocketData))");
+        free(manager);
+        return NULL;
+    }
     manager->free_indices = (int *)malloc(max_size * sizeof(int));
+    if (manager->free_indices == NULL)
+    {
+        perror("malloc(max_size * sizeof(int))");
+        free(manager->sockets);
+        free(manager);
+        return NULL;
+    }
     manager->max_size = max_size;
     manager->top = max_size - 1;
 
@@ -24,6 +43,11 @@ SocketManager *new_socket_manager(int max_size)
 
 SocketData *find_socket(SocketManager *manager, int socket_fd)
 {
+    if (manager == NULL)
+    {
+        return NULL;
+    }
+
     for (int i = 0; i < manager->max_size; i++)
     {
         if (manager->sockets[i].socket_fd == socket_fd)
@@ -36,6 +60,11 @@ SocketData *find_socket(SocketManager *manager, int socket_fd)
 
 SocketData *add_socket(SocketManager *manager, int socket_fd)
 {
+    if (manager == NULL)
+    {
+        return NULL;
+    }
+
     if (manager->top < 0)
     {
         return NULL;
@@ -47,11 +76,20 @@ SocketData *add_socket(SocketManager *manager, int socket_fd)
 
 int get_socket_count(SocketManager *manager)
 {
+    if (manager == NULL)
+    {
+        return -1;
+    }
     return (manager->max_size - 1) - manager->top;
 }
 
 int remove_socket(SocketManager *manager, int socket_fd)
 {
+    if (manager == NULL)
+    {
+        return -1;
+    }
+
     for (int i = 0; i < manager->max_size; i++)
     {
         if (manager->sockets[i].socket_fd == socket_fd)
@@ -66,6 +104,11 @@ int remove_socket(SocketManager *manager, int socket_fd)
 
 void free_socket_manager(SocketManager *manager)
 {
+    if (manager == NULL)
+    {
+        return;
+    }
+
     for (int i = 0; i < manager->max_size; i++)
     {
         if (manager->sockets[i].socket_fd != -1)
@@ -75,6 +118,7 @@ void free_socket_manager(SocketManager *manager)
     }
     free(manager->sockets);
     free(manager->free_indices);
+    free(manager);
 }
 
 int parse_port(const char *port_str)

--- a/utils.h
+++ b/utils.h
@@ -17,6 +17,8 @@ typedef struct
     SocketType type;
     int socket_fd;
     char buffer[BUFFER_SIZE]; // TODO: Use dynamic memory allocation for the buffer
+    size_t buffer_start;
+    size_t buffer_end;
 } SocketData;
 
 typedef struct

--- a/utils.h
+++ b/utils.h
@@ -30,7 +30,6 @@ typedef struct
 } SocketManager;
 
 SocketManager *new_socket_manager(int max_size);
-SocketData *find_socket(SocketManager *manager, int socket_fd); // NO USE
 SocketData *add_socket(SocketManager *manager, SocketType type, int socket_fd);
 int get_socket_count(SocketManager *manager);
 int remove_socket(SocketManager *manager, int socket_fd);

--- a/utils.h
+++ b/utils.h
@@ -19,7 +19,7 @@ typedef struct
     int top;
 } SocketManager;
 
-void init_socket_manager(SocketManager *manager, int max_size);
+SocketManager *new_socket_manager(int max_size);
 SocketData *find_socket(SocketManager *manager, int socket_fd);
 int add_socket(SocketManager *manager, int socket_fd);
 int remove_socket(SocketManager *manager, int socket_fd);

--- a/utils.h
+++ b/utils.h
@@ -21,7 +21,7 @@ typedef struct
 
 SocketManager *new_socket_manager(int max_size);
 SocketData *find_socket(SocketManager *manager, int socket_fd);
-int add_socket(SocketManager *manager, int socket_fd);
+SocketData *add_socket(SocketManager *manager, int socket_fd);
 int remove_socket(SocketManager *manager, int socket_fd);
 void free_socket_manager(SocketManager *manager);
 

--- a/utils.h
+++ b/utils.h
@@ -23,7 +23,7 @@ SocketManager *new_socket_manager(int max_size);
 SocketData *find_socket(SocketManager *manager, int socket_fd);
 int add_socket(SocketManager *manager, int socket_fd);
 int remove_socket(SocketManager *manager, int socket_fd);
-int close_all_sockets(SocketManager *manager);
+void free_socket_manager(SocketManager *manager);
 
 int parse_port(const char *port_str);
 int close_with_retry(int fd);

--- a/utils.h
+++ b/utils.h
@@ -5,8 +5,16 @@
 
 #define BUFFER_SIZE 256
 
+typedef enum
+{
+    LISTEN_SOCKET,
+    CLIENT_SOCKET,
+    SIGNAL_PIPE,
+} SocketType;
+
 typedef struct
 {
+    SocketType type;
     int socket_fd;
     char buffer[BUFFER_SIZE]; // TODO: Use dynamic memory allocation for the buffer
 } SocketData;
@@ -20,8 +28,8 @@ typedef struct
 } SocketManager;
 
 SocketManager *new_socket_manager(int max_size);
-SocketData *find_socket(SocketManager *manager, int socket_fd);
-SocketData *add_socket(SocketManager *manager, int socket_fd);
+SocketData *find_socket(SocketManager *manager, int socket_fd); // NO USE
+SocketData *add_socket(SocketManager *manager, SocketType type, int socket_fd);
 int get_socket_count(SocketManager *manager);
 int remove_socket(SocketManager *manager, int socket_fd);
 void free_socket_manager(SocketManager *manager);

--- a/utils.h
+++ b/utils.h
@@ -22,6 +22,7 @@ typedef struct
 SocketManager *new_socket_manager(int max_size);
 SocketData *find_socket(SocketManager *manager, int socket_fd);
 SocketData *add_socket(SocketManager *manager, int socket_fd);
+int get_socket_count(SocketManager *manager);
 int remove_socket(SocketManager *manager, int socket_fd);
 void free_socket_manager(SocketManager *manager);
 


### PR DESCRIPTION
### Description

https://github.com/thonda28/c-echo/pull/2 の続き（https://github.com/thonda28/c-echo/pull/2 に続けると煩雑になると判断したため、PR を分離）

2025/01/27 に小西さんにいただいたコメント（[このコメント以降のもの](https://github.com/thonda28/c-echo/pull/2#discussion_r1929533938)）に対する対応を行う（詳細は以下に記入）

- SocketManager まわりの修正
    - メモリ確保を `new_socket_manager()` に、メモリ解放を `free_socket_manager()` に修正
    - `find_socket()` は O(N) かかるため、`epoll_event->data->ptr` に `SocketData` のポインタをもたせることで性能改善
- SocketData まわりの修正
    - `SocketType` を設定し、Type を見て処理を分岐
        - 元々 `SocketData` を `find_socket(client_socket_manager, events[i].data.fd)` のように取得したためどんなソケットかが判断できたが、ポインタから直接辿れるようになると `listen_socket` なのか `client_socket` かの判断がつかなくなったため
        - PIPE もまとめて `Socket` という扱いに入れている部分は微妙なので命名あたりを修正したほうがよさそう
    - `SocketData` に `buffer_start` と `buffer_end` を追加し、それらを使って `recv()/send()` 時のバッファを管理
- SIGINT がきたときの安全な終了
    - `listen_socket_manager` と `client_socket_manager` を解放してから `break`（`epoll_wait()` がブロックしないようにタイムアウトも設定）
    - `socket_manager` が解放されていなくても一定時間経過後に `break`
- その他比較的小さめな修正
    - Makefile で `$@` や `$^` という特殊変数を使用
    - エラー時の `puts()` は `fputs()` を使って標準エラー出力へ出力
        - `puts()` は改行あり、`fputs()` は改行なしという差分に気づいたので、そのあたりも整理
    - int 型にもかかわらず `is_xxx` となっていた変数名を修正
    - ほぼ同じコードの共通化
    - ひとまとまりの処理を関数化して分離
    - SIGPIPE の対応をしなくてよいように `MSG_NOSIGNAL` フラグを `send()` に設定
    - などなど

コミットを細かめに分けたので、コミット単位で見ていただくのがわかりやすいかもです。

### Note

3点わかっていない点があり、それは https://github.com/thonda28/c-echo/pull/2 の [コメント](https://github.com/thonda28/c-echo/pull/2#pullrequestreview-2597782920) に返信（以下詳細）

- `remove_socket()` を O(1) にする方法
    - https://github.com/thonda28/c-echo/pull/2#discussion_r1929958695
- 送り返すデータがない場合には EPOLLOUT を受け取らない方法
    - https://github.com/thonda28/c-echo/pull/2#discussion_r1929957445
- SIGINT を受信した際に `EWOULDBLOCK` が起き、再度ループに入ったときに何が起こるか
    - https://github.com/thonda28/c-echo/pull/2#discussion_r1929940257
